### PR TITLE
Use log package to fix lint error

### DIFF
--- a/main.go
+++ b/main.go
@@ -136,14 +136,14 @@ func getECRImageScanFindings(repositories []string) ([]findingsInfo, error) {
 				if aerr, ok := err.(awserr.Error); ok {
 					switch aerr.Code() {
 					case "ScanNotFoundException":
-						fmt.Printf("Skip the repository %v with imageTag %v. %v\n", repo, imageTag, err.Error())
+						log.Printf("Skip the repository %v with imageTag %v. %v\n", repo, imageTag, err.Error())
 					case "ImageNotFoundException":
-						fmt.Printf("Skip the repository %v with imageTag %v. %v\n", repo, imageTag, err.Error())
+						log.Printf("Skip the repository %v with imageTag %v. %v\n", repo, imageTag, err.Error())
 					default:
 						return nil, fmt.Errorf("failed to describe image scan findings: %w", err)
 					}
 				} else if findings.ImageScanFindings == nil {
-					fmt.Printf("Skip the repository %v with imageTag %v. ImageScanStatus: Status %v Description %v\n", repo, imageTag, findings.ImageScanStatus.Status, findings.ImageScanStatus.Description)
+					log.Printf("Skip the repository %v with imageTag %v. ImageScanStatus: Status %v Description %v\n", repo, imageTag, findings.ImageScanStatus.Status, findings.ImageScanStatus.Description)
 				} else {
 					results = generateFindingsInfos(findings, imageTag, repo)
 				}


### PR DESCRIPTION
Use logger to fix lint error

```
main.go:139:7: use of `fmt.Printf` forbidden by pattern `^fmt\.Print(|f|ln)$` (forbidigo)
						fmt.Printf("Skip the repository %v with imageTag %v. %v\n", repo, imageTag, err.Error())
						^
```