### PR TITLE
Use golangci-lint action

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -23,8 +23,7 @@ jobs:
     - name: Test
       run: go test -v ./...
 
-    - name: install lint
-      run: curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.35.2
-
-    - name: lint
-      run: golangci-lint run
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
+      with:
+        version: v1.35.2


### PR DESCRIPTION
CI failed.

```
golangci-lint run
  shell: /usr/bin/bash -e {0}
  env:
    GOROOT: /opt/hostedtoolcache/go/1.15.15/x64
/home/runner/work/_temp/641bc19[3](https://github.com/chaspy/aws-ecr-image-scan-findings-prometheus-exporter/actions/runs/5271494397/jobs/9532449994?pr=67#step:7:3)-5a18-[4](https://github.com/chaspy/aws-ecr-image-scan-findings-prometheus-exporter/actions/runs/5271494397/jobs/9532449994?pr=67#step:7:4)2d2-bd99-0814[5](https://github.com/chaspy/aws-ecr-image-scan-findings-prometheus-exporter/actions/runs/5271494397/jobs/9532449994?pr=67#step:7:5)788fc3[6](https://github.com/chaspy/aws-ecr-image-scan-findings-prometheus-exporter/actions/runs/5271494397/jobs/9532449994?pr=67#step:7:7).sh: line 1: golangci-lint: command not found
Error: Process completed with exit code 12[7](https://github.com/chaspy/aws-ecr-image-scan-findings-prometheus-exporter/actions/runs/5271494397/jobs/9532449994?pr=67#step:7:8).
```

https://github.com/chaspy/aws-ecr-image-scan-findings-prometheus-exporter/actions/runs/5271494397/jobs/9532449994?pr=67